### PR TITLE
Refs #6570 - Remove index pages from sidebar listings

### DIFF
--- a/_includes/sidebars/developer_guide.html
+++ b/_includes/sidebars/developer_guide.html
@@ -1,6 +1,6 @@
 <ul>
   <li class="nav-item">
-    <a href="{{ site.baseurl }}/docs/developer_guide/index.html">Developer Guide</a>
+    <a href="#">Developer Guide</a>
 
     <ul class="sub-context-nav">
       {% for page in site.pages %}

--- a/_includes/sidebars/reference_guide.html
+++ b/_includes/sidebars/reference_guide.html
@@ -1,6 +1,6 @@
 <ul>
   <li class="nav-item">
-    <a href="{{ site.baseurl }}/docs/reference_guide/glossary.html">Reference Guide</a>
+    <a href="#">Reference Guide</a>
 
     <ul class="sub-context-nav">
       {% for page in site.pages %}

--- a/_includes/sidebars/style_guide.html
+++ b/_includes/sidebars/style_guide.html
@@ -1,6 +1,6 @@
 <ul>
   <li class="nav-item">
-    <a href="{{ site.baseurl }}/docs/developer_guide/index.html">Style Guides</a>
+    <a href="#">Style Guides</a>
 
     <ul class="sub-context-nav">
       {% for page in site.pages %}

--- a/_includes/sidebars/user_guide.html
+++ b/_includes/sidebars/user_guide.html
@@ -1,6 +1,6 @@
 <ul>
   <li class="nav-item">
-    <a href="{{ site.baseurl }}/docs/user_guide/index.html">User Guide</a>
+    <a href="#">User Guide</a>
 
     <ul class="sub-context-nav">
       {% for page in site.pages %}

--- a/docs/developer_guide/index.md
+++ b/docs/developer_guide/index.md
@@ -1,9 +1,0 @@
----
-layout: base
-title: Developer Guides
-sidebar: sidebars/documentation.html
----
-
-# Developer Guides
-
-Please use the left hand navigation menu to view documentation.

--- a/docs/developer_guide/style/index.md
+++ b/docs/developer_guide/style/index.md
@@ -1,9 +1,0 @@
----
-layout: base
-title: Style Guides
-sidebar: sidebars/documentation.html
----
-
-# Style Guides
-
-Please use the left hand navigation menu to view documentation.

--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -1,9 +1,0 @@
----
-layout: base
-title: User Guides
-sidebar: sidebars/documentation.html
----
-
-# User Guides
-
-Please use the left hand navigation menu to view documentation.


### PR DESCRIPTION
The index pages show up in the sidebars now so this change removes them and just links the header links to the docs index which instructs users to click a link on the left.
