### PR TITLE
Fixes #6579 - Fixing code blocks in our documentation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,3 +5,4 @@ pygments: true
 
 kramdown:
   auto_id: true
+  input: GFM


### PR DESCRIPTION
**TL;DR:** kramdown doesn't support ``` language syntax blocks so we have to use ~~~ instead. Alternatively, we could switch back to redcarpet for markdown rendering.
