### PR TITLE
Fixes #7295 - Sort the user guide pages alphabetically

### DIFF
--- a/_includes/sidebars/user_guide.html
+++ b/_includes/sidebars/user_guide.html
@@ -3,7 +3,8 @@
     <a href="#">User Guide</a>
 
     <ul class="sub-context-nav">
-      {% for page in site.pages %}
+      {% assign sorted_pages = site.pages | sort:"path" %}
+      {% for page in sorted_pages %}
         {% if page.path contains "docs/user_guide" %}
           <li class="nav-item">
             <a href="{{ site.base_url }}{{ page.url }}">{{ page.title }}</a>


### PR DESCRIPTION
We could also sort the pages by other values (like we could add a weighted value). I'd propose we wait on that though until we have more pages.
