### PR TITLE
Update index.md

### DIFF
--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -104,7 +104,7 @@ wget http://dev.centos.org/centos/6/SCL/scl.repo -O /etc/yum.repos.d/scl.repo
 ```bash
 yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/2.0/katello/RHEL/7Server/x86_64/katello-repos-latest.rpm
 yum -y localinstall http://yum.theforeman.org/releases/1.6/el7/x86_64/foreman-release.rpm
-yum -y localinstall http://mirror.pnl.gov/epel/7/x86_64/epel-release-7-2.noarch.rpm
+yum -y localinstall http://mirror.pnl.gov/epel/7/x86_64/e/epel-release-7-2.noarch.rpm
 yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
 yum -y localinstall https://www.softwarecollections.org/en/scls/rhscl/v8314/epel-7-x86_64/download/rhscl-v8314-epel-7-x86_64.noarch.rpm
 yum -y localinstall https://www.softwarecollections.org/en/scls/rhscl/ruby193/epel-7-x86_64/download/rhscl-ruby193-epel-7-x86_64.noarch.rpm


### PR DESCRIPTION
Updated URL for epel-release-7-2.noarch.rpm. It is now under the 'e' directory.
