### PR TITLE
Add JS runtime to development env

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "http://rubygems.org"
 
 group :development do
+  gem 'therubyracer'
   gem 'jekyll'
   gem 'kramdown'
   gem 'pygments.rb'


### PR DESCRIPTION
After bundle install I get this

``` shell
stbenjam@origin ~/git/katello.org (CLI*) $ jekyll serve
/home/stbenjam/.rvm/gems/ruby-2.0.0-p576/gems/execjs-2.2.1/lib/execjs/runtimes.rb:51:in `autodetect': Could not find a JavaScript runtime. See https://github.com/sstephenson/execjs for a list of available runtimes. (ExecJS::RuntimeUnavailable)
```
