### PR TITLE
Make managing installation URLs easier

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -23,5 +23,9 @@
 
     <script src="{{ site.baseurl }}/assets/js/jquery.min.js"></script>
     <script src="{{ site.baseurl }}/assets/js/bootstrap.min.js"></script>
+
+    {% if page.script %}
+      <script src="{{ site.baseurl }}/assets/js/{{ page.script }}"></script>
+    {% endif %}
   </body>
 </html>

--- a/assets/js/osmenu.js
+++ b/assets/js/osmenu.js
@@ -1,0 +1,30 @@
+$(document).ready(function(){
+  $('#operatingSystems').change(function() {
+    switch($(this).val()) {
+      case "rhel6":
+        $('#rhel6').show();
+        $('#rhel7').hide();
+        $('#el6').show();
+        $('#el7').hide();
+      break;
+      case "rhel7":
+        $('#rhel6').hide();
+        $('#rhel7').show();
+        $('#el6').hide();
+        $('#el7').show();
+      break;
+      case "el6":
+        $('#rhel6').hide();
+        $('#rhel7').hide();
+        $('#el6').show();
+        $('#el7').hide();
+        break;
+      case "el7":
+        $('#rhel6').hide();
+        $('#rhel7').hide();
+        $('#el6').hide();
+        $('#el7').show();
+        break;
+    }
+  });
+});

--- a/docs/installation/development.md
+++ b/docs/installation/development.md
@@ -30,10 +30,10 @@ yum install katello-installer
 ```
 git clone https://github.com/Katello/katello-installer.git
 cd katello-installer
-``` 
+```
 
-The development installer has a variety of options that may be set prior to running the installation. 
-For example, if you have already created a user on the system or have a preferred user name and password these can be configured. 
+The development installer has a variety of options that may be set prior to running the installation.
+For example, if you have already created a user on the system or have a preferred user name and password these can be configured.
 Options can be configured via the answer file or through command line options when running the installer.
 
 **RPM**

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -2,6 +2,7 @@
 layout: documentation
 title: Installation
 sidebar: sidebars/documentation.html
+script: osmenu.js
 ---
 
 # Installation
@@ -11,6 +12,7 @@ For previous versions - {% for version in site.versions %}[{{ version }}](/docs/
 {% endif %}
 
 For development installation instructions see - [development install](/docs/installation/development.html).
+
 For Katello 1.4 users looking for information on how to transition to 2.0, please see - [Transition Guide](/docs/installation/2.0-transition.html).
 
 Note: After installation of Katello, be sure to trust Katello's CA certificate on your system.  This is required for the encrypted NoVNC connections. You will find `katello-default-ca.crt` in the `/pub` directory of your Katello server (e.g. `http://katello.example.com/pub/katello-default-ca.crt`).
@@ -41,66 +43,39 @@ The following ports need to be open to external connections:
 Katello provides a puppet based installer for deploying production installations. Production installations are supported on the following OSes:
 
 ```
+|-----------+-----|
 | OS        |     |
 |-----------|-----|
 | CentOS 6  |  X  |
 | CentOS 7  |  X  |
 | RHEL 6    |  X  |
 | RHEL 7    |  X  |
+|-----------+-----|
 ```
 
 Katello can only run on an x86_64 operating systems.
 
 Installation may be done manually or via our recommended approach of using [katello-deploy](#katello-deploy).
 
+## Required Repositories
 
-### Setup
-
-RPMs of the bleeding edge code are generated every 12 hours and may be installed as a production type installation. We do not recommend nor guarantee the stability of the nightlies. The repository RPMs for nightlies are:
-
- * RHEL6 / CentOS 6:
-
-       http://fedorapeople.org/groups/katello/releases/yum/nightly/katello/RHEL/6Server/x86_64/katello-repos-latest.rpm
-
- * RHEL7 / CentOS 7:
-
-       http://fedorapeople.org/groups/katello/releases/yum/nightly/katello/RHEL/7Server/x86_64/katello-repos-latest.rpm
-
-Depending on your OS, you may need to take some additional steps to get your environment setup prior to running the setup steps. For all installations the Katello, and Foreman repositories need to be setup along with a few external repositories.
-
-### Time Service
-
-The machine should be set up with a valid time service, since several Katello features will not function well if there is minor clock skew.
-
-### RHEL
-
-Depending on the version of RHEL you are installing on, you'll need to perform the following:
-
-**RHEL6**
-
+<p>Select your Operating System: <select id="operatingSystems">
+   <option value="rhel6">Red Hat Enterprise Linux 6</option>
+   <option value="rhel7">Red Hat Enterprise Linux 7</option>
+   <option value="el6">Enterprise Linux 6 (CentOS, etc.)</option>
+   <option value="el7">Enterprise Linux 7 (CentOS, etc.)</option>
+   </select>
+</p>
+<div id="rhel6" markdown="1">
 ```bash
 yum -y  --disablerepo="*" --enablerepo=rhel-6-server-rpms install yum-utils wget
 yum-config-manager --disable "*"
 yum-config-manager --enable rhel-6-server-rpms epel
 yum-config-manager --enable rhel-6-server-optional-rpms
 ```
+</div>
 
-**RHEL7**
-
-```bash
-yum -y  --disablerepo="*" --enablerepo=rhel-7-server-rpms install yum-utils wget
-yum-config-manager --disable "*"
-yum-config-manager --enable rhel-7-server-rpms epel
-yum-config-manager --enable rhel-7-server-optional-rpms
-yum-config-manager --enable rhel-7-server-extras-rpms
-```
-
-### Enteprise Linux
-
-For all variations of enterprise linux (CentOS and RHEL) the following steps need to be taken:
-
-**EL6**
-
+<div id="el6" markdown="1">
 ```bash
 yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/nightly/katello/RHEL/6Server/x86_64/katello-repos-latest.rpm
 yum -y localinstall http://yum.theforeman.org/nightly/el6/x86_64/foreman-release.rpm
@@ -108,19 +83,30 @@ yum -y localinstall http://mirror.pnl.gov/epel/6/x86_64/epel-release-6-8.noarch.
 yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
 wget http://dev.centos.org/centos/6/SCL/scl.repo -O /etc/yum.repos.d/scl.repo
 ```
+</div>
 
-**EL7**
+<div id="rhel7" style="display: none;" markdown="1">
+```bash
+yum -y  --disablerepo="*" --enablerepo=rhel-7-server-rpms install yum-utils wget
+yum-config-manager --disable "*"
+yum-config-manager --enable rhel-7-server-rpms
+yum-config-manager --enable rhel-7-server-optional-rpms
+yum-config-manager --enable rhel-7-server-extras-rpms
+```
+</div>
 
+<div id="el7" style="display: none;" markdown="1">
 ```bash
 yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/nightly/katello/RHEL/7Server/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/nightly/x86_64/foreman-release.rpm
+yum -y localinstall http://yum.theforeman.org/nightly/el7/x86_64/foreman-release.rpm
 yum -y localinstall http://mirror.pnl.gov/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
 yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
 yum -y localinstall https://www.softwarecollections.org/en/scls/rhscl/v8314/epel-7-x86_64/download/rhscl-v8314-epel-7-x86_64.noarch.rpm
 yum -y localinstall https://www.softwarecollections.org/en/scls/rhscl/ruby193/epel-7-x86_64/download/rhscl-ruby193-epel-7-x86_64.noarch.rpm
 ```
+</div>
 
-### Install
+## Installation
 
 After setting up the appropriate repositories, install Katello:
 
@@ -134,6 +120,13 @@ At this point the `katello-installer` should be available to setup the server. T
 katello-installer --help
 ```
 
+<div class="alert alert-info" markdown="1">
+**Note**
+
+Prior to running the installer, the machine should be set up with a time service such as ntpd or chrony, since several Katello features will not function well if there is minor clock skew.
+</div>
+
+
 These may be set as command line options or in the answer file (/etc/katello-installer/answers.katello-installer.yaml). Now run the options:
 
 ```bash
@@ -143,4 +136,5 @@ katello-installer <options>
 ## Katello Deploy
 
 Katello provides a git repository designed to streamline setup by setting up all the proper repositories. Katello deploy provides the ability to deploy a virtual machine instance via Vagrant or direct deployment on an already provisioned machine. For details on how to install using katello-deploy, please see the [README](https://github.com/Katello/katello-deploy/blob/master/README.md).
+
 

--- a/docs/user_guide/capsules/index.md
+++ b/docs/user_guide/capsules/index.md
@@ -60,46 +60,7 @@ The following ports need to be open to external connections:
 
 ### Preparing the Capsule server
 
-The same yum repositories need to be configured on the Capsule server as the main Katello server.  You may wish to sync all of these and have the Capsule server install from Katello instead of the upstream Repositories.
-
-**Enterprise Linux**
-
-For Enterprise Linux, we require the Katello repos, EPEL and the appropriate set of Software Collection repositories for Ruby 1.9.3.
-
-For EL6:
-
-```
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/2.0/katello/RHEL/6Server/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/1.6/el6/x86_64/foreman-release.rpm
-yum -y localinstall http://mirror.pnl.gov/epel/6/x86_64/epel-release-6-8.noarch.rpm
-yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
-wget http://dev.centos.org/centos/6/SCL/scl.repo -O /etc/yum.repos.d/scl.repo
-```
-
-For EL7:
-
-```
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/2.0/katello/RHEL/7Server/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/1.6/el7/x86_64/foreman-release.rpm
-yum -y localinstall http://mirror.pnl.gov/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
-yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
-yum -y localinstall https://www.softwarecollections.org/en/scls/rhscl/v8314/epel-7-x86_64/download/rhscl-v8314-epel-7-x86_64.noarch.rpm
-yum -y localinstall https://www.softwarecollections.org/en/scls/rhscl/ruby193/epel-7-x86_64/download/rhscl-ruby193-epel-7-x86_64.noarch.rpm
-```
-
-**Red Hat Enterprise Linux**
-
-Katello requires your RHEL to be registered to Red Hat channels/repos. We also require the RHEL optional RPMs repo is enabled:
-
-```
-$ yum-config-manager --enable rhel-6-server-optional-rpms
-```
-
-For RHEL 7:
-
-```
-$ yum-config-manager --enable rhel-7-server-optional-rpms
-```
+The same yum repositories need to be configured on the Capsule server as the main Katello server.  See the installation guide for the [list of required repositories](http://localhost:4000/docs/{{ site.version }}/installation/index.html#required-repositories).
 
 ### Install needed packages:
 

--- a/docs/user_guide/disconnected/index.md
+++ b/docs/user_guide/disconnected/index.md
@@ -50,59 +50,12 @@ DESCRIPTION
 
 To start with *katello-disconnected* there are a series of steps you need to take to get it installed and configured. The installation should take place on your Synchronization Server seen above.  This system is the one that has access to the internet and Red Hat's CDN servers.  These instructions point at the ''katello nightly'' builds but you can substitute this for the latest stable version of Katello if you desire.
 
-**1)** Configure repositories on your Synchronization Server:
-
-**Enterprise Linux**
-
-For Enterprise Linux, we require the Katello repos, EPEL and the appropriate set of Software Collection repositories for Ruby 1.9.3.
-
-For EL6:
-
-```
-$ rpm -Uvh http://fedorapeople.org/groups/katello/releases/yum/2.0/katello/RHEL/6/x86_64/katello-repos-latest.rpm
-$ rpm -Uvh http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
-$ rpm -Uvh https://www.softwarecollections.org/en/scls/rhscl/ruby193/epel-6-x86_64/download/rhscl-ruby193-epel-6-x86_64.noarch.rpm
-$ rpm -Uvh http://yum.theforeman.org/releases/1.6/el6/x86_64/foreman-release.rpm
-$ yum-config-manager --enable rhel-6-server-optional-rpms
-```
-
-For EL7:
-
-```
-$ rpm -Uvh http://fedorapeople.org/groups/katello/releases/yum/2.0/katello/RHEL/7/x86_64/katello-repos-latest.rpm
-$ rpm -Uvh http://download-i2.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
-$ rpm -Uvh https://www.softwarecollections.org/en/scls/rhscl/v8314/epel-7-x86_64/download/rhscl-v8314-epel-7-x86_64.noarch.rpm
-$ rpm -Uvh https://www.softwarecollections.org/en/scls/rhscl/ruby193/epel-7-x86_64/download/rhscl-ruby193-epel-7-x86_64.noarch.rpm
-$ rpm -Uvh http://yum.theforeman.org/releases/1.6/el7/x86_64/foreman-release.rpm
-$ yum-config-manager --enable rhel-7-server-optional-rpms
-```
-
-**Red Hat Enterprise Linux**
-
-Katello requires your RHEL to be registered to Red Hat channels/repos. We also require the RHEL optional RPMs repo is enabled:
-
-```
-$ yum-config-manager --enable rhel-6-server-optional-rpms
-```
-
-For RHEL 7:
-
-```
-$ yum-config-manager --enable rhel-7-server-optional-rpms
-```
-
-**CentOS**
-
-For CentOS, add the following:
-
-```
-$ wget -O /etc/yum.repos.d/epel-rhsm.repo http://repos.fedorapeople.org/repos/candlepin/subscription-manager/epel-subscription-manager.repo
-```
+**1)** Configure repositories on your Synchronization Server [as per our installation guide](http://localhost:4000/docs/{{ site.version }}/installation/index.html#required-repositories).
 
 **2)** Install katello-utils and associated RPMs:
 
 ```
-$ yum -y install python-qpid-qmf python-qpid  qpid-cpp-server-store katello-utils
+$ yum -y install python-qpid-qmf python-qpid qpid-cpp-server-store katello-utils
 ```
 
 This will install roughly 200 packages depending on your pre-existing configuration.

--- a/docs/user_guide/hammer.md
+++ b/docs/user_guide/hammer.md
@@ -6,20 +6,13 @@ commands can be run from the command line or used in shell scripts.
 
 ## Installation
 
-The Hammer package is installed as part of Katello. Alternatively, Hammer 
+The Hammer package is installed as part of Katello. Alternatively, Hammer
 can be installed and run from a remote system as long as it can connect to
 Katello via HTTP or HTTPS.
 
 ### Remote install
 
-Install the prerequisite rpms as [per our installation guide](TODO). For EL6,
-this would be:
-
-```
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/2.0/katello/RHEL/6Server/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/1.6/el6/x86_64/foreman-release.rpm
-yum -y localinstall http://mirror.pnl.gov/epel/6/x86_64/epel-release-6-8.noarch.rpm
-```
+Install the prerequisite repositories [as per our installation guide](http://localhost:4000/docs/{{ site.version }}/installation/index.html#required-repositories).
 
 Now install the hammer-cli-katello package:
 
@@ -113,7 +106,7 @@ Options:
  --description DESCRIPTION               Product description
  --gpg-key GPG_KEY_NAME                  Name to search by
  --gpg-key-id GPG_KEY_ID                 gpg key numeric identifier
- --label LABEL                            
+ --label LABEL
  --name NAME                             Product name
  --organization ORGANIZATION_NAME        Organization name to search by
  --organization-id ORGANIZATION_ID       organization ID


### PR DESCRIPTION
This adds a dropdown menu to the installation page for the OS, and removes all of the other URL's sprinkled throughout the docs.  My javascript skills are not so good, so maybe there's something cleaner to be done.

