### PR TITLE
Deploy with no arguments when not testing a PR

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ namespace :test do
     sh 'git clone https://github.com/Katello/katello.org.git -b deploy deploy'
 
     Dir.chdir 'deploy' do
-      if (pr = ENV['TRAVIS_PULL_REQUEST']) && !pr.empty?
+      if (pr = ENV['TRAVIS_PULL_REQUEST']) && pr =~ /\A[0-9]+\z/
         sh "./deploy.rb --pr #{pr}"
       else
         sh "./deploy.rb"


### PR DESCRIPTION
ENV['TRAVIS_PULL_REQUEST'] is "false" not empty when not testing a PR. https://travis-ci.org/Katello/katello.org/builds/50064259#L146
