### PR TITLE
updated ktest to remove the test runner

### DIFF
--- a/developers/testing.md
+++ b/developers/testing.md
@@ -152,7 +152,7 @@ if [[ -n $1 ]]
 then
   RAKE_PATH=`bundle show rake`
   ruby -I"lib:test:${KATELLO_PATH}/test:${KATELLO_PATH}/spec" -I"${RAKE_PATH}/lib" \
-    "${RAKE_PATH}/lib/rake/rake_test_loader.rb" $@ ${KATELLO_PATH}/test/katello_test_runner.rb
+    "${RAKE_PATH}/lib/rake/rake_test_loader.rb" $@
 else
   bundle exec rake test:katello
 fi


### PR DESCRIPTION
Since there is no more test runner in katello/master, ktest needs to be updated to not use the test runner.