### PR TITLE
refs #11787 - look up foreman version in hash instead

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,12 @@ markdown: KramdownPygments
 highlighter: pygments
 latest: 2.3
 
-foreman_version: nightly
+version: nightly
+
+foreman_versions:
+    'nightly': nightly
+    '2.4': 'releases/1.10'
+    '2.3': 'releases/1.9'
 
 version_aliases:
   '2.4': 2.4-RC

--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,8 @@ foreman_versions:
     '2.4': 'releases/1.10'
     '2.3': 'releases/1.9'
 
+doc_url: /docs
+
 version_aliases:
   '2.4': 2.4-RC
 

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -12,7 +12,7 @@
         <ul class="dropdown-menu">
             {% for version in site.versions reversed %}
               <li>
-                <a href="/docs/{{ version }}/" {% if site.latest == version %}style="font-weight: bold;"{% endif %}>
+                <a href="/docs/{{ version }}" {% if site.latest == version %}style="font-weight: bold;"{% endif %}>
                   {% if site.version_aliases[version] %}
                     {{ site.version_aliases[version] }}
                   {% else %}

--- a/_includes/sidebars/documentation.html
+++ b/_includes/sidebars/documentation.html
@@ -2,49 +2,49 @@
 
   <ul>
     <li class="nav-item">
-      <a href="{{ site.baseurl }}/docs/{{ site.version }}/installation/index.html">Installation</a>
+      <a href="{{ site.baseurl }}{{ site.doc_url }}/installation/index.html">Installation</a>
       <ul class="sub-context-nav">
         <li class="nav-item">
-          <a href="{{ site.baseurl }}/docs/{{ site.version }}/installation/index.html">Katello</a>
+          <a href="{{ site.baseurl }}{{ site.doc_url }}/installation/index.html">Katello</a>
         </li>
         <li class="nav-item">
-          <a href="{{ site.baseurl }}/docs/{{ site.version }}/installation/capsule.html">Capsule</a>
+          <a href="{{ site.baseurl }}{{ site.doc_url }}/installation/capsule.html">Capsule</a>
         </li>
         <li class="nav-item">
-          <a href="{{ site.baseurl }}/docs/{{ site.version }}/installation/clients.html">Clients</a>
+          <a href="{{ site.baseurl }}{{ site.doc_url }}/installation/clients.html">Clients</a>
         </li>
       </ul>
     </li>
   </ul>
   <ul>
     <li class="nav-item">
-      <a href="{{ site.baseurl }}/docs/{{ site.version }}/upgrade/index.html">Upgrade</a>
+      <a href="{{ site.baseurl }}{{ site.doc_url }}/upgrade/index.html">Upgrade</a>
       <ul class="sub-context-nav">
         <li class="nav-item">
-          <a href="{{ site.baseurl }}/docs/{{ site.version }}/upgrade/index.html">Katello</a>
+          <a href="{{ site.baseurl }}{{ site.doc_url }}/upgrade/index.html">Katello</a>
         </li>
         <li class="nav-item">
-          <a href="{{ site.baseurl }}/docs/{{ site.version }}/upgrade/capsule.html">Capsule</a>
+          <a href="{{ site.baseurl }}{{ site.doc_url }}/upgrade/capsule.html">Capsule</a>
         </li>
         <li class="nav-item">
-          <a href="{{ site.baseurl }}/docs/{{ site.version }}/upgrade/clients.html">Clients</a>
+          <a href="{{ site.baseurl }}{{ site.doc_url }}/upgrade/clients.html">Clients</a>
         </li>
       </ul>
     </li>
   </ul>
   <ul>
     <li class="nav-item">
-      <a href="{{ site.baseurl }}/docs/{{ site.version }}/release_notes/release_notes.html">Release Notes</a>
+      <a href="{{ site.baseurl }}{{ site.doc_url }}/release_notes/release_notes.html">Release Notes</a>
     </li>
   </ul>
   <ul>
     <li class="nav-item">
-      <a href="{{ site.baseurl }}/docs/{{ site.version }}/api/index.html">API</a>
+      <a href="{{ site.baseurl }}{{ site.doc_url }}/api/index.html">API</a>
     </li>
   </ul>
   <ul>
     <li class="nav-item">
-      <a href="{{ site.baseurl }}/docs/{{ site.version }}/cli/index.html">CLI</a>
+      <a href="{{ site.baseurl }}{{ site.doc_url }}/cli/index.html">CLI</a>
     </li>
   </ul>
 

--- a/_includes/sidebars/user_guide.html
+++ b/_includes/sidebars/user_guide.html
@@ -1,6 +1,6 @@
 <ul>
   <li class="nav-item">
-    <a href="/docs/{{ site.version }}/user_guide/">User Guide</a>
+    <a href="{{ site.doc_url }}/user_guide/">User Guide</a>
 
     <ul class="sub-context-nav">
       {% assign sorted_pages = site.pages | sort:"path" %}
@@ -8,7 +8,7 @@
         {% if page.path contains "user_guide" %}
           {% unless page.path contains "user_guide/index" %}
             <li class="nav-item">
-              <a href="{{ site.base_url }}/docs/{{ site.version }}/user_guide/{{ page.url | split:'user_guide/' | last }}">{{ page.title }}</a>
+              <a href="{{ site.base_url }}{{ site.doc_url }}/user_guide/{{ page.url | split:'user_guide/' | last }}">{{ page.title }}</a>
             </li>
           {% endunless %}
         {% endif %}

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -37,7 +37,7 @@ yum-config-manager --enable rhel-6-server-optional-rpms
 <div id="el6" markdown="1">
 ```bash
 yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/katello/RHEL/6Server/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/{{ site.foreman_version }}/el6/x86_64/foreman-release.rpm
+yum -y localinstall http://yum.theforeman.org/{{ site.foreman_versions[site.version] }}/el6/x86_64/foreman-release.rpm
 yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 ```
 </div>
@@ -55,7 +55,7 @@ yum-config-manager --enable rhel-7-server-extras-rpms
 <div id="el7" style="display: none;" markdown="1">
 ```bash
 yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/katello/RHEL/7Server/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/{{ site.foreman_version }}/el7/x86_64/foreman-release.rpm
+yum -y localinstall http://yum.theforeman.org/{{ site.foreman_versions[site.version] }}/el7/x86_64/foreman-release.rpm
 yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 ```
 </div>

--- a/docs/installation/capsule.md
+++ b/docs/installation/capsule.md
@@ -13,7 +13,7 @@ The Capsule server is only supported on x86_64 Operating Systems
 
  * 2 Two Logical CPUs
  * 4 GB of memory
- * Disk space usage is similar to that of the main Katello server [Installation](/docs/{{ site.version }}/installation/index.html)
+ * Disk space usage is similar to that of the main Katello server [Installation]({{ site.doc_url }}/installation/index.html)
 
 
 ## Required Ports
@@ -24,7 +24,7 @@ At a minimum, the following ports need to be open to external connections for in
 * 443 TCP - HTTPS, used for web access and api communication
 * 9090 TCP - HTTPS - used for communication with the smart proxy
 
-See the [User Guide](/docs/{{ site.version }}/user_guide/capsules/index.html) for additional information about Capsule services and required ports.
+See the [User Guide]({{ site.doc_url }}/user_guide/capsules/index.html) for additional information about Capsule services and required ports.
 
 ## Installation
 
@@ -71,7 +71,7 @@ Installing             Done                     [100%] [.....................]
 
 ### Install needed packages:
 
-The same yum repositories need to be configured on the Capsule server as the main Katello server. See the installation guide for the [list of required repositories](/docs/{{ site.version }}/installation/index.html#required-repositories).
+The same yum repositories need to be configured on the Capsule server as the main Katello server. See the installation guide for the [list of required repositories]({{ site.doc_url }}/installation/index.html#required-repositories).
 
 ```
 yum install -y capsule-installer
@@ -81,4 +81,4 @@ yum install -y capsule-installer
 
 Use the provide installation command from `capsule-certs-generate`, and tailor for your own purposes as needed.  The defaults will give you a Capsule ready for Content-related services.
 
-See the [User Guide](/docs/{{ site.version }}/user_guide/capsules/index.html) to learn about setting up provisioning related services, as well as the [Foreman manual](http://theforeman.org/manuals/latest/index.html#4.3SmartProxies)
+See the [User Guide]({{ site.doc_url }}/user_guide/capsules/index.html) to learn about setting up provisioning related services, as well as the [Foreman manual](http://theforeman.org/manuals/latest/index.html#4.3SmartProxies)

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -92,7 +92,7 @@ yum-config-manager --enable rhel-6-server-optional-rpms
 <div id="el6" markdown="1">
 ```bash
 yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/katello/RHEL/6Server/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/{{ site.foreman_version }}/el6/x86_64/foreman-release.rpm
+yum -y localinstall http://yum.theforeman.org/{{ site.foreman_versions[site.version] }}/el6/x86_64/foreman-release.rpm
 yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
 yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 yum -y install foreman-release-scl

--- a/docs/upgrade/capsule.md
+++ b/docs/upgrade/capsule.md
@@ -26,14 +26,14 @@ Update the Foreman and Katello release packages:
 
 ```
   # yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/katello/RHEL/6Server/x86_64/katello-repos-latest.rpm
-  # yum update -y http://yum.theforeman.org/{{ site.foreman_version }}/el6/x86_64/foreman-release.rpm
+  # yum update -y http://yum.theforeman.org/{{ site.foreman_versions[site.version] }}/el6/x86_64/foreman-release.rpm
 ```
 
   * RHEL7 / CentOS 7:
 
 ```
   # yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/katello/RHEL/7Server/x86_64/katello-repos-latest.rpm
-  # yum update -y http://yum.theforeman.org/{{ site.foreman_version }}/el7/x86_64/foreman-release.rpm
+  # yum update -y http://yum.theforeman.org/{{ site.foreman_versions[site.version] }}/el7/x86_64/foreman-release.rpm
 ```
 
 ## Step 3 - Update Packages

--- a/docs/upgrade/capsule.md
+++ b/docs/upgrade/capsule.md
@@ -74,7 +74,7 @@ The installer with the --upgrade flag will run the right database migrations for
                     --certs-update-all --regenerate --deploy
 ```
 
-**Congratulations! You have now successfully upgraded your Capsule to {% if site.version %}{{ site.version }} For a rundown of what was added, please see [release notes](/docs/{{ site.version }}/release_notes/release_notes.html).{% else %}the latest nightly{% endif %}!**
+**Congratulations! You have now successfully upgraded your Capsule to {% if site.version %}{{ site.version }} For a rundown of what was added, please see [release notes]({{ site.doc_url }}/release_notes/release_notes.html).{% else %}the latest nightly{% endif %}!**
 
 If for any reason, the above steps failed, please review /var/log/capsule-installer/capsule-installer.log -- if any of the "Upgrade step" tasks failed, you may try to run them manaully below to aid in troubleshooting.
 

--- a/docs/upgrade/clients.md
+++ b/docs/upgrade/clients.md
@@ -58,7 +58,7 @@ yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ site.versio
 
 ### Provisioned Clients
 
-If the katello-agent was setup during proviosioning from a locally synced repository then you will need to go through some [initial setup](/docs/{{ site.version }}/installation/clients.html) to add the {{ site.version }} client repositories to your Katello for each version needed. After you create the new repositories, they will then need to be added to the relevant content view(s) and the older versions removed. At this point, a new version of the content view can be published and promoted to the appropriate environments. Once the new package is available the clients can be updated following the next steps.
+If the katello-agent was setup during proviosioning from a locally synced repository then you will need to go through some [initial setup]({{ site.baseurl }}{{ site.doc_url }}/installation/clients.html) to add the {{ site.version }} client repositories to your Katello for each version needed. After you create the new repositories, they will then need to be added to the relevant content view(s) and the older versions removed. At this point, a new version of the content view can be published and promoted to the appropriate environments. Once the new package is available the clients can be updated following the next steps.
 
 ## Step 2: Update Packages
 

--- a/docs/upgrade/index.md
+++ b/docs/upgrade/index.md
@@ -30,14 +30,14 @@ Update the Foreman and Katello release packages:
 
 ```
   # yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/katello/RHEL/6Server/x86_64/katello-repos-latest.rpm
-  # yum update -y http://yum.theforeman.org/{{ site.foreman_version }}/el6/x86_64/foreman-release.rpm
+  # yum update -y http://yum.theforeman.org/{{ site.foreman_versions[site.version] }}/el6/x86_64/foreman-release.rpm
 ```
 
   * RHEL7 / CentOS 7:
 
 ```
   # yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/katello/RHEL/7Server/x86_64/katello-repos-latest.rpm
-  # yum update -y http://yum.theforeman.org/{{ site.foreman_version }}/el7/x86_64/foreman-release.rpm
+  # yum update -y http://yum.theforeman.org/{{ site.foreman_versions[site.version] }}/el7/x86_64/foreman-release.rpm
 ```
 
 ## Step 4 - Update Packages

--- a/docs/upgrade/index.md
+++ b/docs/upgrade/index.md
@@ -6,11 +6,11 @@ sidebar: sidebars/documentation.html
 
 # Katello Upgrade
 
-Katello supports upgrades from version 2.0.  For users transitioning from 1.4, please see - [Transition Guide](/docs/{{ site.version }}/installation/2.0-transition.html).
+Katello supports upgrades from version 2.0.  For users transitioning from 1.4, please see - [Transition Guide]({{ site.doc_url }}/installation/2.0-transition.html).
 
 ## Step 1 - Backup
 
-If Katello is running on a Virtual Machine, we reccomend to take a snapshot prior to upgrading. Otherwise, take a backup of the relevant databases by following the [instructions here](/docs/{{ site.version }}/user_guide/backup/).
+If Katello is running on a Virtual Machine, we reccomend to take a snapshot prior to upgrading. Otherwise, take a backup of the relevant databases by following the [instructions here]({{ site.doc_url }}/user_guide/backup/).
 
 ## Step 2 - Operating System
 
@@ -62,7 +62,7 @@ The installer with the --upgrade flag will run the right database migrations for
 # katello-installer --upgrade
 ```
 
-**Congratulations! You have now successfully upgraded your Katello to {% if site.version %}{{ site.version }} For a rundown of what was added, please see [release notes](/docs/{{ site.version }}/release_notes/release_notes.html).{% else %}the latest nightly{% endif %}!**
+**Congratulations! You have now successfully upgraded your Katello to {% if site.version %}{{ site.version }} For a rundown of what was added, please see [release notes]({{ site.doc_url }}/release_notes/release_notes.html).{% else %}the latest nightly{% endif %}!**
 
 
 If for any reason, the above steps failed, please review /var/log/katello-installer/katello-installer.log -- if any of the "Upgrade step" tasks failed, you may try to run them manaully below to aid in troubleshooting.

--- a/docs/user_guide/capsules/index.md
+++ b/docs/user_guide/capsules/index.md
@@ -39,7 +39,7 @@ In the simplest use case, a user may only want to use the Default Capsule. Large
 
 ## Installation
 
-See [Capsule Installation](/docs/{{ site.version }}/installation/capsule.html)
+See [Capsule Installation]({{ site.doc_url }}/installation/capsule.html)
 
 ## Removal
 
@@ -95,7 +95,7 @@ Required Connectivity:
 
 ### 4 - Subscription Management
 
-Content Hosts utilize [Subscription Manager](/docs/{{ site.version }}/user_guide/content_hosts/index.html#how-is-a-content-host-registered) for registration to Katello and enabling/disabling specific repositories.
+Content Hosts utilize [Subscription Manager]({{ site.doc_url }}/user_guide/content_hosts/index.html#how-is-a-content-host-registered) for registration to Katello and enabling/disabling specific repositories.
 
 Install Option:
 

--- a/docs/user_guide/disconnected/index.md
+++ b/docs/user_guide/disconnected/index.md
@@ -50,7 +50,7 @@ DESCRIPTION
 
 To start with *katello-disconnected* there are a series of steps you need to take to get it installed and configured. The installation should take place on your Synchronization Server seen above.  This system is the one that has access to the internet and Red Hat's CDN servers.  These instructions point at the ''katello nightly'' builds but you can substitute this for the latest stable version of Katello if you desire.
 
-**1)** Configure repositories on your Synchronization Server [as per our installation guide](/docs/{{ site.version }}/installation/index.html#required-repositories).
+**1)** Configure repositories on your Synchronization Server [as per our installation guide]({{ site.doc_url }}/installation/index.html#required-repositories).
 
 **2)** Install katello-utils and associated RPMs:
 

--- a/docs/user_guide/hammer.md
+++ b/docs/user_guide/hammer.md
@@ -12,7 +12,7 @@ Katello via HTTP or HTTPS.
 
 ### Remote install
 
-Install the prerequisite repositories [as per our installation guide](/docs/{{ site.version }}/installation/index.html#required-repositories).
+Install the prerequisite repositories [as per our installation guide]({{ site.doc_url }}/installation/index.html#required-repositories).
 
 Now install the hammer-cli-katello package:
 

--- a/docs/user_guide/lifecycle_environments/environment.md
+++ b/docs/user_guide/lifecycle_environments/environment.md
@@ -21,7 +21,7 @@ What can a Lifecycle Environments be used for?
 ## General Workflow
 
 First create a lifecycle environment connected to the library life cycle environment and promote content views to the new lifecycle environment.
-A [Content Host](/docs/{{ site.version }}/user_guide/content_hosts/index.html) can now register directly to the promoted content view in the promoted environment or library therein.  Updates will be available as soon as new content is synced and promoted.
+A [Content Host]({{ site.doc_url }}/user_guide/content_hosts/index.html) can now register directly to the promoted content view in the promoted environment or library therein.  Updates will be available as soon as new content is synced and promoted.
 
 
 ## Viewing the list of lifecycle environments


### PR DESCRIPTION
The problem is the master _config.yml gets merged with the individual version's _config.yaml, so it was always setting foreman_version to nightly. Using a hash will fix it.

Also to 2.3 and 2.4: https://github.com/Katello/katello.org/pull/205, https://github.com/Katello/katello.org/pull/206