### PR TITLE
Use origin in build directly when working with alternate remote

### DIFF
--- a/deploy.rb
+++ b/deploy.rb
@@ -112,7 +112,7 @@ class Deployer
     puts "Building version #{version}"
     reset_nightly
 
-    branch = "remotes/#{remote}/KATELLO-#{version}"
+    branch = "remotes/origin/KATELLO-#{version}"
 
     FileUtils.rmdir('public/docs/' + version)
 


### PR DESCRIPTION
@jlsherrill When using an alternate remote, it becomes "origin" once its checked out in _build. I needed this change to make it work.
