### PR TITLE
Minor typo in forman url generation

### DIFF
--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -112,7 +112,7 @@ yum-config-manager --enable rhel-7-server-extras-rpms
 <div id="el7" style="display: none;" markdown="1">
 ```bash
 yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/katello/RHEL/7Server/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/{{ site.foreman_verison }}/el7/x86_64/foreman-release.rpm
+yum -y localinstall http://yum.theforeman.org/{{ site.foreman_version  }}/el7/x86_64/foreman-release.rpm
 yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
 yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum -y install foreman-release-scl


### PR DESCRIPTION
There was a minor typo which caused the foreman repo url to be http://yum.theforeman.org//el7/x86_64/foreman-release.rpm for both RHEL 7 and CentOS 7
instead of http://yum.theforeman.org/releases/1.10/el7/x86_64/foreman-release.rpm