### PR TITLE
2.3 - missing links for v8314 and rub193 scl for el7

### DIFF
--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -102,6 +102,8 @@ yum -y localinstall http://yum.theforeman.org/{{ site.foreman_verison }}/el7/x86
 yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
 yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum -y install foreman-release-scl
+yum -y localinstall https://www.softwarecollections.org/en/scls/rhscl/v8314/epel-7-x86_64/download/rhscl-v8314-epel-7-x86_64.noarch.rpm
+yum -y localinstall https://www.softwarecollections.org/en/scls/rhscl/ruby193/epel-7-x86_64/download/rhscl-ruby193-epel-7-x86_64.noarch.rpm
 ```
 </div>
 


### PR DESCRIPTION
The current documentation is missing links for v8314 and ruby193 SCL repositories for el7 and yum install katello fails. 

Current: 

yum install katello
...
...
Error: Package: ruby193-rubygem-tire-0.6.2-1.el7.noarch (katello)
           Requires: ruby193-rubygem(activesupport)                                                        
Error: Package: rubygem-apipie-bindings-0.0.10-2.el7.noarch (epel)                                         
           Requires: rubygem(awesome_print)                                                                
Error: Package: ruby193-rubygem-katello-2.3.1-2.el7.noarch (katello)                                       
           Requires: ruby193-rubygem-foreman-tasks >= 0.7.1                                                
Error: Package: ruby193-rubygem-haml-rails-0.4-1.el7.noarch (katello)                                      
           Requires: ruby193-rubygem(activesupport) >= 3.0                                                 
Error: Package: ruby193-rubygem-katello-2.3.1-2.el7.noarch (katello)                                       
           Requires: ruby193-rubygem-oauth                                                                 
Error: Package: ruby193-rubygem-hashr-0.0.22-5.el7.noarch (katello)                                        
           Requires: ruby193-ruby-wrapper                                                                  
Error: Package: rubygem-hammer_cli_katello-0.0.17-2.el7.noarch (katello)                                   
           Requires: rubygem(hammer_cli_foreman_bootdisk)                                                  
Error: Package: ruby193-rubygem-tire-0.6.2-1.el7.noarch (katello)                                          
           Requires: ruby193-rubygem-multi_json                                                            
Error: Package: ruby193-rubygem-deface-0.7.2-6.el7.noarch (katello)                                        
           Requires: ruby193-rubygem(rails)                                                                
Error: Package: katello-2.3.0-6.el7.noarch (katello)                                                       
           Requires: foreman-libvirt                                                                       
Error: Package: ruby193-rubygem-katello-2.3.1-2.el7.noarch (katello)                                       
           Requires: ruby193-rubygem-rails                                                                 
Error: Package: katello-2.3.0-6.el7.noarch (katello)                                                       
           Requires: ruby193-rubygem-foreman_bootdisk                                                      
Error: Package: ruby193-rubygem-qpid_messaging-0.30.0-1.el7.x86_64 (katello)                               
           Requires: ruby193-ruby(abi) = 1.9.1                                                             
Error: Package: ruby193-rubygem-haml-4.0.6-1.el7.noarch (katello)                                          
           Requires: ruby193-rubygem(ruby_parser)                                                          
Error: Package: katello-common-2.3.0-6.el7.noarch (katello)                                                
           Requires: rubygem-hammer_cli                                                                    
Error: Package: ruby193-rubygem-haml-4.0.6-1.el7.noarch (katello)                                          
           Requires: ruby193-rubygem(sass)                                                                 
Error: Package: ruby193-rubygem-tire-0.6.2-1.el7.noarch (katello)                                          
           Requires: ruby193-rubygem(rest-client) >= 1.6                                                   
Error: Package: ruby193-rubygem-runcible-1.3.5-1.el7.noarch (katello)                                      
           Requires: ruby193-rubygem(json)                                                                 
Error: Package: ruby193-rubygem-tire-0.6.2-1.el7.noarch (katello)                                          
           Requires: ruby193-ruby(abi) = 1.9.1                                                             
Error: Package: ruby193-rubygem-katello-2.3.1-2.el7.noarch (katello)                                       
           Requires: ruby193-rubygems                                                                      
Error: Package: ruby193-rubygem-katello-2.3.1-2.el7.noarch (katello)                                       
           Requires: ruby193-rubygem-angular-rails-templates >= 0.0.4                                      
Error: Package: ruby193-rubygem-haml-rails-0.4-1.el7.noarch (katello)                                      
           Requires: ruby193-rubygems                                                                      
Error: Package: ruby193-rubygem-hashr-0.0.22-5.el7.noarch (katello)                                        
           Requires: ruby193-rubygems                                                                      
Error: Package: ruby193-rubygem-runcible-1.3.5-1.el7.noarch (katello)                                      
           Requires: ruby193-rubygem(oauth)                                                                
Error: Package: ruby193-rubygem-i18n_data-0.2.7-3.el7.noarch (katello)                                     
           Requires: ruby193-ruby(abi) = 1.9.1                                                             
Error: Package: ruby193-rubygem-katello-2.3.1-2.el7.noarch (katello)                                       
           Requires: ruby193-rubygem-foreman_docker >= 0.2.0                                               
Error: Package: ruby193-rubygem-haml-rails-0.4-1.el7.noarch (katello)                                      
           Requires: ruby193-rubygem(rails) >= 3.0                                                         
Error: Package: rubygem-hammer_cli_katello-0.0.17-2.el7.noarch (katello)                                   
           Requires: rubygem(hammer_cli_foreman_docker)                                                    
Error: Package: ruby193-rubygem-katello-2.3.1-2.el7.noarch (katello)                                       
           Requires: ruby193-rubygem-bastion < 3.0.0                                                       
Error: Package: ruby193-rubygem-hpricot-0.8.6-11.el7.x86_64 (katello)                                      
           Requires: libruby.so.1.9()(64bit)                                                               
Error: Package: ruby193-rubygem-anemone-0.7.2-10.el7.noarch (katello)                                      
           Requires: /opt/rh/ruby193/root/usr/bin/ruby                                                     
Error: Package: rubygem-hammer_cli_katello-0.0.17-2.el7.noarch (katello)                                   
           Requires: rubygem(hammer_cli) >= 0.1.3                                                          
Error: Package: ruby193-rubygem-haml-rails-0.4-1.el7.noarch (katello)                                      
           Requires: ruby193-rubygem(actionpack) >= 3.0                                                    
Error: Package: ruby193-rubygem-haml-rails-0.4-1.el7.noarch (katello)                                      
           Requires: ruby193-rubygem(railties) >= 3.0                                                      
Error: Package: ruby193-rubygem-haml-4.0.6-1.el7.noarch (katello)                                          
           Requires: /opt/rh/ruby193/root/usr/bin/ruby                                                     
Error: Package: katello-debug-2.3.0-6.el7.noarch (katello)                                                 
           Requires: foreman-debug                                                                         
Error: Package: ruby193-rubygem-justified-0.0.4-2.el7.noarch (katello)                                     
           Requires: ruby193-rubygems                                                                      
Error: Package: ruby193-rubygem-hpricot-0.8.6-11.el7.x86_64 (katello)                                      
           Requires: ruby193-ruby(abi) = 1.9.1                                                             
Error: Package: ruby193-rubygem-hooks-0.2.2-6.el7.noarch (katello)                                         
           Requires: ruby193-ruby(abi) = 1.9.1                                                             
Error: Package: ruby193-rubygem-i18n_data-0.2.7-3.el7.noarch (katello)                                     
           Requires: ruby193-rubygem(activesupport) >= 0                                                   
Error: Package: ruby193-rubygem-haml-rails-0.4-1.el7.noarch (katello)                                      
           Requires: ruby193-ruby(abi) = 1.9.1                                                             
Error: Package: ruby193-rubygem-katello-2.3.1-2.el7.noarch (katello)                                       
           Requires: ruby193-rubygem-less-rails                                                            
Error: Package: katello-2.3.0-6.el7.noarch (katello)                                                       
           Requires: ruby193-rubygem-foreman_hooks                                                         
Error: Package: rubygem-hammer_cli_import-0.10.20-1.el7.noarch (katello)                                   
           Requires: rubygem(hammer_cli)                                                                   
Error: Package: ruby193-rubygem-strong_parameters-0.2.1-11.el7.noarch (katello)                            
           Requires: ruby193-rubygems                                                                      
Error: Package: ruby193-rubygem-qpid_messaging-0.30.0-1.el7.x86_64 (katello)                               
           Requires: libruby.so.1.9()(64bit)                                                               
Error: Package: katello-2.3.0-6.el7.noarch (katello)                                                       
           Requires: foreman-vmware                                                                        
Error: Package: rubygem-apipie-bindings-0.0.10-2.el7.noarch (epel)                                         
           Requires: rubygem(oauth)                                                                        
Error: Package: ruby193-rubygem-katello-2.3.1-2.el7.noarch (katello)                                       
           Requires: ruby193-rubygem-foreman-tasks < 0.8.0                                                 
Error: Package: ruby193-rubygem-katello-2.3.1-2.el7.noarch (katello)                                       
           Requires: foreman >= 1.9.0                                                                      
Error: Package: katello-2.3.0-6.el7.noarch (katello)                                                       
           Requires: foreman-gce                                                                           
Error: Package: ruby193-rubygem-runcible-1.3.5-1.el7.noarch (katello)                                      
           Requires: ruby193-rubygem(rest-client) >= 1.6.1                                                 
Error: Package: ruby193-rubygem-runcible-1.3.5-1.el7.noarch (katello)                                      
           Requires: ruby193-rubygem(rest-client) < 1.8.0                                                  
Error: Package: ruby193-rubygem-hpricot-0.8.6-11.el7.x86_64 (katello)                                      
           Requires: ruby193-ruby(rubygems)                                                                
Error: Package: ruby193-rubygem-justified-0.0.4-2.el7.noarch (katello)                                     
           Requires: ruby193-ruby(abi) = 1.9.1                                                             
Error: Package: ruby193-rubygem-strong_parameters-0.2.1-11.el7.noarch (katello)                            
           Requires: ruby193-rubygem(actionpack) >= 3.0                                                    
Error: Package: ruby193-rubygem-strong_parameters-0.2.1-11.el7.noarch (katello)                            
           Requires: ruby193-ruby(abi) = 1.9.1                                                             
Error: Package: ruby193-rubygem-ansi-1.4.3-3.el7.noarch (katello)                                          
           Requires: ruby193-ruby-wrapper                                                                  
Error: Package: ruby193-rubygem-robotex-1.0.0-16.el7.noarch (katello)                                      
           Requires: ruby193-ruby(abi) = 1.9.1                                                             
Error: Package: ruby193-rubygem-hooks-0.2.2-6.el7.noarch (katello)                                         
           Requires: ruby193-ruby(rubygems)                                                                
Error: Package: ruby193-rubygem-anemone-0.7.2-10.el7.noarch (katello)                                      
           Requires: ruby193-ruby(abi) = 1.9.1                                                             
Error: Package: ruby193-rubygem-runcible-1.3.5-1.el7.noarch (katello)                                      
           Requires: ruby193-rubygem(i18n) >= 0.5.0                                                        
Error: Package: ruby193-rubygem-strong_parameters-0.2.1-11.el7.noarch (katello)                            
           Requires: ruby193-ruby-wrapper                                                                  
Error: Package: ruby193-rubygem-i18n_data-0.2.7-3.el7.noarch (katello)                                     
           Requires: ruby193-rubygems                                                                      
Error: Package: katello-2.3.0-6.el7.noarch (katello)                                                       
           Requires: foreman-ovirt                                                                         
Error: Package: ruby193-rubygem-katello-2.3.1-2.el7.noarch (katello)                                       
           Requires: ruby193-rubygem-gettext_i18n_rails                                                    
Error: Package: ruby193-rubygem-ansi-1.4.3-3.el7.noarch (katello)                                          
           Requires: ruby193-rubygems                                                                      
Error: Package: ruby193-rubygem-katello-2.3.1-2.el7.noarch (katello)                                       
           Requires: ruby193-ruby(abi) >= 1.9.1                                                            
Error: Package: ruby193-rubygem-anemone-0.7.2-10.el7.noarch (katello)                                      
           Requires: ruby193-rubygem-nokogiri >= 1.3.0                                                     
Error: Package: ruby193-rubygem-runcible-1.3.5-1.el7.noarch (katello)                                      
           Requires: ruby193-ruby(abi) = 1.9.1                                                             
Error: Package: ruby193-rubygem-haml-4.0.6-1.el7.noarch (katello)                                          
           Requires: ruby193-rubygem(erubis)                                                               
Error: Package: ruby193-rubygem-katello-2.3.1-2.el7.noarch (katello)                                       
           Requires: ruby193-rubygem-json                                                                  
Error: Package: ruby193-rubygem-strong_parameters-0.2.1-11.el7.noarch (katello)                            
           Requires: ruby193-rubygem(railties) >= 3.0                                                      
Error: Package: ruby193-rubygem-tire-0.6.2-1.el7.noarch (katello)                                          
           Requires: ruby193-rubygem(activemodel) >= 3.0                                                   
Error: Package: ruby193-rubygem-katello-2.3.1-2.el7.noarch (katello)                                       
           Requires: ruby193-rubygem-jquery-ui-rails                                                       
Error: Package: katello-installer-base-2.3.1-6.el7.noarch (katello)                                        
           Requires: rubygem-kafo                                                                          
Error: Package: ruby193-rubygem-robotex-1.0.0-16.el7.noarch (katello)                                      
           Requires: ruby193-rubygems                                                                      
Error: Package: ruby193-rubygem-deface-0.7.2-6.el7.noarch (katello)                                        
           Requires: ruby193-rubygem(nokogiri)                                                             
Error: Package: ruby193-rubygem-katello-2.3.1-2.el7.noarch (katello)                                       
           Requires: ruby193-rubygem-rest-client                                                           
Error: Package: ruby193-rubygem-robotex-1.0.0-16.el7.noarch (katello)                                      
           Requires: ruby193-ruby-wrapper
Error: Package: ruby193-rubygem-tire-0.6.2-1.el7.noarch (katello)
           Requires: ruby193-rubygems
Error: Package: katello-installer-base-2.3.1-6.el7.noarch (katello)
           Requires: foreman-selinux
Error: Package: ruby193-rubygem-strong_parameters-0.2.1-11.el7.noarch (katello)
           Requires: ruby193-rubygem(activemodel) < 4
Error: Package: ruby193-rubygem-hashr-0.0.22-5.el7.noarch (katello)
           Requires: ruby193-ruby(abi) = 1.9.1
Error: Package: katello-common-2.3.0-6.el7.noarch (katello)
           Requires: rubygem-hammer_cli_foreman
Error: Package: ruby193-rubygem-deface-0.7.2-6.el7.noarch (katello)
           Requires: ruby193-rubygems
Error: Package: ruby193-rubygem-strong_parameters-0.2.1-11.el7.noarch (katello)
           Requires: ruby193-rubygem(activemodel) >= 3.0
Error: Package: ruby193-rubygem-katello-2.3.1-2.el7.noarch (katello)
           Requires: ruby193-rubygem-apipie-rails >= 0.1.1
Error: Package: ruby193-rubygem-deface-0.7.2-6.el7.noarch (katello)
           Requires: ruby193-ruby(abi) = 1.9.1
Error: Package: rubygem-hammer_cli_gutterball-1.0.0-1.el7.noarch (katello)
           Requires: rubygem(hammer_cli) >= 0.1.1
Error: Package: ruby193-rubygem-haml-4.0.6-1.el7.noarch (katello)
           Requires: ruby193-ruby(rubygems)
Error: Package: ruby193-rubygem-katello-2.3.1-2.el7.noarch (katello)
           Requires: ruby193-rubygem-rabl
Error: Package: ruby193-rubygem-foreman_gutterball-0.0.1-1.201507061443gitb9974c7.git.0.64e9626.el7.noarch (katello)
           Requires: ruby193-rubygems
Error: Package: ruby193-rubygem-strong_parameters-0.2.1-11.el7.noarch (katello)
           Requires: ruby193-rubygem(railties) < 4
Error: Package: ruby193-rubygem-tire-0.6.2-1.el7.noarch (katello)
           Requires: ruby193-rubygem(rake)
Error: Package: ruby193-rubygem-foreman_gutterball-0.0.1-1.201507061443gitb9974c7.git.0.64e9626.el7.noarch (katello)
           Requires: ruby193-ruby-wrapper
Error: Package: ruby193-rubygem-runcible-1.3.5-1.el7.noarch (katello)
           Requires: ruby193-ruby(rubygems)
Error: Package: rubygem-hammer_cli_katello-0.0.17-2.el7.noarch (katello)
           Requires: rubygem(hammer_cli_foreman_tasks) >= 0.0.3
Error: Package: ruby193-rubygem-hpricot-0.8.6-11.el7.x86_64 (katello)
           Requires: ruby193-ruby-wrapper
Error: Package: ruby193-rubygem-haml-rails-0.4-1.el7.noarch (katello)
           Requires: ruby193-rubygem(bundler) >= 1.0.0
Error: Package: ruby193-rubygem-qpid_messaging-0.30.0-1.el7.x86_64 (katello)
           Requires: ruby193-ruby(rubygems)
Error: Package: rubygem-hammer_cli_import-0.10.20-1.el7.noarch (katello)
           Requires: rubygem(hammer_cli_foreman)
Error: Package: ruby193-rubygem-strong_parameters-0.2.1-11.el7.noarch (katello)
           Requires: ruby193-rubygem(actionpack) < 4
Error: Package: katello-selinux-2.2.1-1.el7.noarch (katello)
           Requires: foreman-selinux >= 1.8
Error: Package: ruby193-rubygem-haml-4.0.6-1.el7.noarch (katello)
           Requires: ruby193-ruby(abi) = 1.9.1
Error: Package: ruby193-rubygem-katello-2.3.1-2.el7.noarch (katello)
           Requires: ruby193-rubygem-bastion >= 2.0.0
Error: Package: ruby193-rubygem-runcible-1.3.5-1.el7.noarch (katello)
           Requires: ruby193-rubygem(activesupport) >= 3.0.10
Error: Package: ruby193-rubygem-anemone-0.7.2-10.el7.noarch (katello)
           Requires: ruby193-rubygems