### PR TITLE
Update zeus documentation

### DIFF
--- a/developers/testing.md
+++ b/developers/testing.md
@@ -65,6 +65,9 @@ require 'zeus/rails'
 class CustomPlan < Zeus::Rails
   def test_environment
     require 'minitest/unit'
+    require 'minitest-spec-rails'
+    require 'minitest-spec-rails/init/active_support'
+    require 'minitest-spec-rails/init/mini_shoulda'
     MiniTest::Unit.class_variable_set("@@installed_at_exit", true)
     $LOAD_PATH.unshift '../katello/test'
     $LOAD_PATH.unshift '../katello/spec'


### PR DESCRIPTION
In latest updates, the test environment started to fail with this error from
test_helper:

```
undefined method `it' for class `Class' (NameError)
```

Requiring the needed files a bit sooner fixes the issue.