### PR TITLE
Update docs to use scenario-based foreman-installer

### DIFF
--- a/docs/installation/capsule.md
+++ b/docs/installation/capsule.md
@@ -47,26 +47,25 @@ Installing             Done                     [100%] [.....................]
 
   To finish the installation, follow these steps:
 
-  1. Ensure that the capsule-installer is available on the system.
-     The capsule-installer comes from the capsule-installer package and
-     should be acquired through the means that are appropriate to your deployment.
+  1. Ensure that the foreman-installer-katello package is installed on the system.
   2. Copy ~/mycapsule.example.com-certs.tar to the system mycapsule.example.com
-  3. Run the following commands on the Capsule (possibly with the customized
-     parameters, see capsule-installer --help and
+  3. Run the following commands on the capsule (possibly with the customized
+     parameters, see foreman-installer --scenario capsule --help and
      documentation for more info on setting up additional services):
 
-  rpm -Uvh http://katello-centos6-2.0.example.com/pub/katello-ca-consumer-latest.noarch.rpm
-  subscription-manager register --org "ACME_Corporation"
-  capsule-installer --parent-fqdn          "katello.example.com"\
-                    --register-in-foreman  "true"\
-                    --foreman-oauth-key    "EwZePUX7erQeYbuMqytLCd4jHndY5iH4"\
-                    --foreman-oauth-secret "K5TmVVsEmc29DCAscJEnupDmHcQQFdc4"\
-                    --pulp-oauth-secret    "7TwngPvBSkJELCAQ4fjEmmY9FUn2UGZJ"\
-                    --certs-tar            "~/mycapsule.example.com-certs.tar"\
-                    --puppet               "true"\
-                    --puppetca             "true"\
-                    --pulp                 "true"
-  The full log is at /var/log/katello-installer/capsule-certs-generate.log
+  yum -y localinstall http://katello.example.com/pub/katello-ca-consumer-latest.noarch.rpm
+  subscription-manager register --org "Default_Organization"
+  foreman-installer --scenario capsule\
+                    --parent-fqdn           "katello.example.com"\
+                    --register-in-foreman   "true"\
+                    --foreman-base-url      "https://katello.example.com"\
+                    --trusted-hosts         "katello.example.com"\
+                    --trusted-hosts         "mycapsule.example.com"\
+                    --oauth-consumer-key    "UVrAZfMaCfBiiWejoUVLYCZHT2xhzuFV"\
+                    --oauth-consumer-secret "ZhH8p7M577ttNU3WmUGWASag3JeXKgUX"\
+                    --pulp-oauth-secret     "TPk42MYZ42nAE3rZvyLBh7Lxob3nEUi8"\
+                    --certs-tar             "~/mycapsule.example.com-certs.tar"
+  The full log is at /var/log/capsule-certs-generate.log
 ```
 
 ### Install needed packages:
@@ -74,7 +73,7 @@ Installing             Done                     [100%] [.....................]
 The same yum repositories need to be configured on the Capsule server as the main Katello server. See the installation guide for the [list of required repositories](/docs/{{ site.version }}/installation/index.html#required-repositories).
 
 ```
-yum install -y capsule-installer
+yum install -y foreman-installer-katello
 ```
 
 ### Install Capsule

--- a/docs/installation/development.md
+++ b/docs/installation/development.md
@@ -6,53 +6,8 @@ sidebar: sidebars/documentation.html
 
 # Development Installation
 
-Katello provides a puppet based installer for deploying development environments. Development deployments are supported on the following OSes:
-
-| OS        | Development |
-|-----------|-------------|
-| CentOS 6  |      X      |
-| RHEL 6    |      X      |
-| Fedora 19 |      X      |
-
-There are two methods to install a development setup: direct or [katello-deploy](#katello-deploy).
-
-### Direct Install
-
-A development environment may be setup through the `katello-devel-installer` if you have already deployed a system with one of the supported OSes. Begin by installing the RPM or cloning the `katello-installer`:
-
-**RPM (example using RHEL6)**
-```
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/nightly/el6/x86_64/katello-repos-latest.rpm
-yum install katello-installer
-```
-
-**Git Repo**
-```
-git clone https://github.com/Katello/katello-installer.git
-cd katello-installer
-```
-
-The development installer has a variety of options that may be set prior to running the installation.
-For example, if you have already created a user on the system or have a preferred user name and password these can be configured.
-Options can be configured via the answer file or through command line options when running the installer.
-
-**RPM**
-```
-vim /etc/katello-installer/answers.katello-devel-installer.yaml
-katello-devel-installer --help
-katello-devel-installer <options>
-```
-
-**Git**
-```
-vim config/answers.katello-devel-installer.yaml
-./bin/katello-devel-installer --help
-./bin/katello-devel-installer <options>
-```
-
-## Katello Deploy
-
-Katello provides a git repository designed to streamline setup by setting up all the proper repositories.
+Katello provides the `katello-deploy` git repository which is designed to streamline setup by setting up all the proper repositories.
 Katello deploy provides the ability to deploy a virtual machine instance via Vagrant or direct deployment on an already provisioned machine.
+
 For details on how to install using katello-deploy, please see the [README](https://github.com/Katello/katello-deploy/blob/master/README.md).
 

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -127,10 +127,10 @@ After setting up the appropriate repositories, install Katello:
 yum -y install katello
 ```
 
-At this point the `katello-installer` should be available to setup the server. The installation may be customized, to see a list of options:
+At this point the `foreman-installer` should be available to setup the server. The installation may be customized, to see a list of options:
 
 ```bash
-katello-installer --help
+foreman-installer --scenario katello --help
 ```
 
 <div class="alert alert-info" markdown="1">
@@ -140,10 +140,10 @@ Prior to running the installer, the machine should be set up with a time service
 </div>
 
 
-These may be set as command line options or in the answer file (/etc/katello-installer/answers.katello-installer.yaml). Now run the options:
+These may be set as command line options or in the answer file (/etc/foreman-installer/scenarios.d/katello-answers.yaml). Now run the options:
 
 ```bash
-katello-installer <options>
+foreman-installer --scenario katello <options>
 ```
 
 ## Katello Deploy

--- a/docs/upgrade/capsule.md
+++ b/docs/upgrade/capsule.md
@@ -70,13 +70,14 @@ And copy them to your capsule:
 The installer with the --upgrade flag will run the right database migrations for all component services, as well as adjusting the configuration to reflect what's new in Katello {{ site.version }}
 
 ```
-# capsule-installer --upgrade --certs-tar ~/mycapsule.example.com-certs.tar\
+# foreman-installer --scenario capsule --upgrade\
+                    --certs-tar ~/mycapsule.example.com-certs.tar\
                     --certs-update-all --regenerate --deploy
 ```
 
 **Congratulations! You have now successfully upgraded your Capsule to {% if site.version %}{{ site.version }} For a rundown of what was added, please see [release notes](/docs/{{ site.version }}/release_notes/release_notes.html).{% else %}the latest nightly{% endif %}!**
 
-If for any reason, the above steps failed, please review /var/log/capsule-installer/capsule-installer.log -- if any of the "Upgrade step" tasks failed, you may try to run them manaully below to aid in troubleshooting.
+If for any reason, the above steps failed, please review /var/log/foreman-installer/capsule.log -- if any of the "Upgrade step" tasks failed, you may try to run them manaully below to aid in troubleshooting.
 
 ## Manual Steps
 

--- a/docs/upgrade/index.md
+++ b/docs/upgrade/index.md
@@ -59,13 +59,13 @@ Update the required packages:
 The installer with the --upgrade flag will run the right database migrations for all component services, as well as adjusting the configuration to reflect what's new in Katello {{ site.version }}
 
 ```
-# katello-installer --upgrade
+# foreman-installer --scenario katello --upgrade
 ```
 
 **Congratulations! You have now successfully upgraded your Katello to {% if site.version %}{{ site.version }} For a rundown of what was added, please see [release notes](/docs/{{ site.version }}/release_notes/release_notes.html).{% else %}the latest nightly{% endif %}!**
 
 
-If for any reason, the above steps failed, please review /var/log/katello-installer/katello-installer.log -- if any of the "Upgrade step" tasks failed, you may try to run them manaully below to aid in troubleshooting.
+If for any reason, the above steps failed, please review /var/log/foreman-installer/katello.log -- if any of the "Upgrade step" tasks failed, you may try to run them manaully below to aid in troubleshooting.
 
 ## Manual Steps
 

--- a/docs/user_guide/backup/index.md
+++ b/docs/user_guide/backup/index.md
@@ -27,7 +27,7 @@ It is necessary to backup configuration files and important data files. Being in
 
 ```
 tar --selinux -czvf config_files.tar.gz \
-/etc/katello-installer \
+/etc/foreman-installer \
 /etc/foreman \
 /etc/elasticsearch \
 /etc/candlepin \
@@ -48,7 +48,7 @@ tar --selinux -czvf config_files.tar.gz \
 tar --selinux -czvf elastic_data.tar.gz /var/lib/elasticsearch
 ```
 
-Please note some of these directories are created after `katello-installer` is executed for the first time.
+Please note some of these directories are created after `foreman-installer` is executed for the first time.
 
 ## Repositories
 
@@ -143,12 +143,12 @@ We are assuming restore is going to happen on the same server the instance from 
 katello-service stop
 ```
 
-If the original system is not avaiable it is necessary to reinstall the same version of Katello, restore the files, and then run `katello-installer`.  **The hostname must rename the same, otherwise you will need to regenerate all SSL certificates.**
+If the original system is not avaiable it is necessary to reinstall the same version of Katello, restore the files, and then run `foreman-installer --scenario katello`.  **The hostname must rename the same, otherwise you will need to regenerate all SSL certificates.**
 
 ```
 yum -y install katello
 tar --selinux -xzvf config_files.tar.gz -C /tmp
-katello-installer
+foreman-installer --scenario katello
 ```
 
 Please note the following process describes full Katello backup restore and it deletes all data that are still loaded. Make sure you are restoring the correct instance. All commands are executed as root in the directory with backup archives created in the Backup chapter above.


### PR DESCRIPTION
This is an initial commit to incorporate documentation changes to support
the scenario-based foreman-installer.  With these changes, the katello-installer
and capsule-installer will go away and the user will use the foreman-installer
providing the desired --scenario input (e.g. 'foreman', 'katello', 'capsule').

Note:
~~- This PR does not yet include details on setting up the development environment using the scenario-based installer.~~
- This PR updates the 'upgrade' section; however, upgrades have not yet been tested for this release; therefore, there may be modifications needed as that work is done.
