### PR TITLE
remove uses of ```` (four backticks)

### DIFF
--- a/docs/user_guide/capsules/index.md
+++ b/docs/user_guide/capsules/index.md
@@ -174,7 +174,7 @@ hammer -u admin -p password  capsule content synchronize --name mycapsule.exampl
 
 to syncronize only a single Lifecycle Environment:
 
-````
+```
 hammer -u admin -p password  capsule content synchronize --name=mycapsule.example.com --environment=Production
 ```
 

--- a/docs/user_guide/hammer.md
+++ b/docs/user_guide/hammer.md
@@ -70,7 +70,7 @@ Subcommands:
  auth                          Foreman connection login/logout.
  capsule                       Manipulate capsule
 ...
-````
+```
 
 To view the subcommands or options for a particular Hammer command, simply run
 that command with the help option (`--help` or `-h`).


### PR DESCRIPTION
The docs builder thought this meant ``` (three backticks), with a language
setting of ` (one backtick).