### PR TITLE
remove uses of ```` (four backticks)

### DIFF
--- a/docs/user_guide/hammer.md
+++ b/docs/user_guide/hammer.md
@@ -70,7 +70,7 @@ Subcommands:
  auth                          Foreman connection login/logout.
  capsule                       Manipulate capsule
 ...
-````
+```
 
 To view the subcommands or options for a particular Hammer command, simply run
 that command with the help option (`--help` or `-h`).


### PR DESCRIPTION
The docs builder thought this meant ``` (three backticks), with a language
setting of ` (one backtick).