### PR TITLE
Fixes nightly not showing up in URLs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,7 @@ highlighter: pygments
 latest: 2.4
 
 foreman_version: nightly
+version: nightly
 
 version_aliases:
 


### PR DESCRIPTION
anywhere ```{{ site.version }}``` is used is currently blank. Adding version as a variable to the config file seems to have fixed that.