### PR TITLE
Removes Nightly option from menu

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -21,7 +21,6 @@
                 </a>
               </li>
             {% endfor %}
-          <li><a href="/docs/">Nightly</a></li>
         </ul>
       </li>
       <li>


### PR DESCRIPTION
The "Nightly" option for our docs is taken care of by our deploy script in this PR https://github.com/Katello/katello.org/pull/248 this will remove the extra "Nightly" in the dropdown menu