### PR TITLE
Update latest to be 3.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ name: Katello
 baseurl:
 markdown: KramdownPygments
 highlighter: pygments
-latest: 2.4
+latest: 3.0
 
 foreman_version: 1.11
 


### PR DESCRIPTION
Currently http://www.katello.org/docs/3.0/installation/index.html reports that 2.4 is the latest stable version. That's not true, 3.0 is.