### PR TITLE
Fixed the wrong URL of the foreman, "releases" should be included

### DIFF
--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -91,7 +91,7 @@ yum-config-manager --enable rhel-6-server-optional-rpms
 <div id="el6" markdown="1">
 ```bash
 yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/katello/el6/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/{{ site.foreman_version }}/el6/x86_64/foreman-release.rpm
+yum -y localinstall http://yum.theforeman.org/releases/{{ site.foreman_version }}/el6/x86_64/foreman-release.rpm
 yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
 yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 yum -y install foreman-release-scl
@@ -111,7 +111,7 @@ yum-config-manager --enable rhel-7-server-extras-rpms
 <div id="el7" style="display: none;" markdown="1">
 ```bash
 yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/{{ site.foreman_version  }}/el7/x86_64/foreman-release.rpm
+yum -y localinstall http://yum.theforeman.org/releases/{{ site.foreman_version  }}/el7/x86_64/foreman-release.rpm
 yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
 yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum -y install foreman-release-scl


### PR DESCRIPTION
I found that the repository of the foreman was wrong. "releases" should be included in the foreman repo. URL.

