### PR TITLE
Update index.md

### DIFF
--- a/docs/upgrade/index.md
+++ b/docs/upgrade/index.md
@@ -42,6 +42,7 @@ Update the Foreman and Katello release packages:
 ```
   # yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/katello/RHEL/6Server/x86_64/katello-repos-latest.rpm
   # yum update -y http://yum.theforeman.org/{{ site.foreman_version }}/el6/x86_64/foreman-release.rpm
+  # yum update -y foreman-release-scl
 ```
 
   * RHEL7 / CentOS 7:
@@ -49,6 +50,7 @@ Update the Foreman and Katello release packages:
 ```
   # yum update -y http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/katello/RHEL/7Server/x86_64/katello-repos-latest.rpm
   # yum update -y http://yum.theforeman.org/{{ site.foreman_version }}/el7/x86_64/foreman-release.rpm
+  # yum update -y foreman-release-scl
 ```
 
 ## Step 4 - Update Packages


### PR DESCRIPTION
At least in my case I had to update the "foreman-release-scl" repo. Otherwise I was facing a broken packages for the "sclo-ror42-rubygem" packages. Basically missing the ruby on rails 4.2
It all occured during upgrade from 3.0 to 3.1