### PR TITLE
fix #theforeman-dev channel name on github workflow page

### DIFF
--- a/developers/github_workflow.md
+++ b/developers/github_workflow.md
@@ -22,7 +22,7 @@ For more information about preparing your pull request and what guidelines your 
 
 ## Contributor Access
 
-When starting out, contributors are added to our "Contributors" team. This allows their pull requests to automatically be run by Jenkins. If you wish to be added to this list, please email [our develop mailing list](https://groups.google.com/forum/#!forum/foreman-dev) or contact a developer via [#foreman-dev on IRC](http://theforeman.org/support.html#IRC).
+When starting out, contributors are added to our "Contributors" team. This allows their pull requests to automatically be run by Jenkins. If you wish to be added to this list, please email [our develop mailing list](https://groups.google.com/forum/#!forum/foreman-dev) or contact a developer via [#theforeman-dev on IRC](http://theforeman.org/support.html#IRC).
 
 ## Write Access
 
@@ -32,7 +32,7 @@ Various [teams](https://github.com/orgs/Katello/teams) exist within the Katello 
 * Must have 3 or more merged pull requests
 * Must have reviewed 3 or more pull requests
 
-We prefer that one of the merged pull requests be a non-trivial bug or feature but we'll consider anyone with three pull requests. If you meet these criteria, please email [our develop mailing list](https://groups.google.com/forum/#!forum/foreman-dev) or contact a developer via [#foreman-dev on IRC](http://theforeman.org/support.html#IRC)).
+We prefer that one of the merged pull requests be a non-trivial bug or feature but we'll consider anyone with three pull requests. If you meet these criteria, please email [our develop mailing list](https://groups.google.com/forum/#!forum/foreman-dev) or contact a developer via [#theforeman-dev on IRC](http://theforeman.org/support.html#IRC)).
 
 Write access will be revoked for inactive members and is subject to being revoked at any time for any reason. Granting write access is also subject to approval from existing team members.
 


### PR DESCRIPTION
the channel is called #theforeman-dev, not #foreman-dev