### PR TITLE
fixes #16875 - set hard_wrap: false for nicer wrapping of text

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,5 +12,6 @@ version_aliases:
 kramdown:
   auto_id: true
   input: GFM
+  hard_wrap: false
 
 exclude: ['vendor']

--- a/_plugins/kramdown-with-pygments/kramdown_pygments.rb
+++ b/_plugins/kramdown-with-pygments/kramdown_pygments.rb
@@ -51,7 +51,7 @@ module Kramdown
         end
         "<code#{html_attributes(attr)}>#{code}</code>"
       end
-      
+
       def pygmentize(code, lang)
         if lang
           Pygments.highlight(code,
@@ -85,7 +85,8 @@ class Jekyll::Converters::Markdown::KramdownPygments
         :toc_levels           => @config['kramdown']['toc_levels'],
         :smart_quotes         => @config['kramdown']['smart_quotes'],
         :kramdown_default_lang => @config['kramdown']['default_lang'],
-        :input                => @config['kramdown']['input']
+        :input                => @config['kramdown']['input'],
+        :hard_wrap            => @config['kramdown']['hard_wrap']
     }).to_pygments_html
     return html;
   end


### PR DESCRIPTION
this also requires an update to the kramdown-with-pygments plugin to properly pass the hard_wrap option to kramdown