### PR TITLE
Fix the latest stable version number

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ name: Katello
 baseurl:
 markdown: KramdownPygments
 highlighter: pygments
-latest: 3.0
+latest: '3.1'
 
 foreman_version: 1.11
 


### PR DESCRIPTION
Currently, the installation page in the [documentation](http://www.katello.org/docs/3.0/installation/index.html) states:

> These instructions are for installing Katello 3.0, but the latest stable is 3.0.

This message is wrong for two reasons:
- 3.0 is equal to itself, but it's parsed as a number in the config file
- the latest stable version _seems_ to be 3.1 (it's set to different values in the different branches; I've decided to beleive the 3.2 branch)

I've set the version to `'3.1'` in this commit.
