### PR TITLE
Add required repositories list to capsule install docs

### DIFF
--- a/_includes/repositories.html
+++ b/_includes/repositories.html
@@ -1,0 +1,45 @@
+<p>Select your Operating System: <select id="operatingSystems">
+   <option value="rhel6">Red Hat Enterprise Linux 6</option>
+   <option value="rhel7">Red Hat Enterprise Linux 7</option>
+   <option value="el6">Enterprise Linux 6 (CentOS, etc.)</option>
+   <option value="el7">Enterprise Linux 7 (CentOS, etc.)</option>
+   </select>
+</p>
+<div id="rhel6" markdown="1">
+```bash
+yum -y  --disablerepo="*" --enablerepo=rhel-6-server-rpms install yum-utils wget
+yum-config-manager --disable "*"
+yum-config-manager --enable rhel-6-server-rpms epel
+yum-config-manager --enable rhel-6-server-optional-rpms
+```
+</div>
+
+<div id="el6" markdown="1">
+```bash
+yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/katello/el6/x86_64/katello-repos-latest.rpm
+yum -y localinstall http://yum.theforeman.org/releases/{{ site.foreman_version }}/el6/x86_64/foreman-release.rpm
+yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
+yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
+yum -y install foreman-release-scl
+```
+</div>
+
+<div id="rhel7" style="display: none;" markdown="1">
+```bash
+yum -y  --disablerepo="*" --enablerepo=rhel-7-server-rpms install yum-utils wget
+yum-config-manager --disable "*"
+yum-config-manager --enable rhel-7-server-rpms
+yum-config-manager --enable rhel-7-server-optional-rpms
+yum-config-manager --enable rhel-7-server-extras-rpms
+```
+</div>
+
+<div id="el7" style="display: none;" markdown="1">
+```bash
+yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/katello/el7/x86_64/katello-repos-latest.rpm
+yum -y localinstall http://yum.theforeman.org/releases/{{ site.foreman_version  }}/el7/x86_64/foreman-release.rpm
+yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
+yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum -y install foreman-release-scl
+```
+</div>

--- a/docs/installation/capsule.md
+++ b/docs/installation/capsule.md
@@ -28,9 +28,13 @@ See the [User Guide](/docs/{{ site.version }}/user_guide/capsules/index.html) fo
 
 ## Installation
 
-### Install needed packages:
+### Setup Repositories:
 
-The same yum repositories need to be configured on the Capsule server as the main Katello server. See the installation guide for the [list of required repositories](/docs/{{ site.version }}/installation/index.html#required-repositories).
+Setup the necessary repositories on your capsule
+
+{% include repositories.html %}
+
+### Install needed packages:
 
 Once you get the repositories configured, install the katello-capsule package on the capsule
 

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -72,51 +72,7 @@ Installation may be done manually or via our recommended approach of using [kate
 
 ## Required Repositories
 
-<p>Select your Operating System: <select id="operatingSystems">
-   <option value="rhel6">Red Hat Enterprise Linux 6</option>
-   <option value="rhel7">Red Hat Enterprise Linux 7</option>
-   <option value="el6">Enterprise Linux 6 (CentOS, etc.)</option>
-   <option value="el7">Enterprise Linux 7 (CentOS, etc.)</option>
-   </select>
-</p>
-<div id="rhel6" markdown="1">
-```bash
-yum -y  --disablerepo="*" --enablerepo=rhel-6-server-rpms install yum-utils wget
-yum-config-manager --disable "*"
-yum-config-manager --enable rhel-6-server-rpms epel
-yum-config-manager --enable rhel-6-server-optional-rpms
-```
-</div>
-
-<div id="el6" markdown="1">
-```bash
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/katello/el6/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ site.foreman_version }}/el6/x86_64/foreman-release.rpm
-yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
-yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
-yum -y install foreman-release-scl
-```
-</div>
-
-<div id="rhel7" style="display: none;" markdown="1">
-```bash
-yum -y  --disablerepo="*" --enablerepo=rhel-7-server-rpms install yum-utils wget
-yum-config-manager --disable "*"
-yum-config-manager --enable rhel-7-server-rpms
-yum-config-manager --enable rhel-7-server-optional-rpms
-yum-config-manager --enable rhel-7-server-extras-rpms
-```
-</div>
-
-<div id="el7" style="display: none;" markdown="1">
-```bash
-yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/katello/el7/x86_64/katello-repos-latest.rpm
-yum -y localinstall http://yum.theforeman.org/releases/{{ site.foreman_version  }}/el7/x86_64/foreman-release.rpm
-yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
-yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-yum -y install foreman-release-scl
-```
-</div>
+{% include repositories.html %}
 
 ## Installation
 After setting up the appropriate repositories, update your system:


### PR DESCRIPTION
Its inconvenient to navigate to another page to get the list of required repositories when reading the capsule install docs. Also, that step is easy to miss since it is only one line with a link. Separating the required repository setup into a different template allows us to show it in both capsule and katello install docs, and update it in one place, making things more explicit.