### PR TITLE
Update stable to 3.2 in Katello 3.2 branch

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ name: Katello
 baseurl:
 markdown: KramdownPygments
 highlighter: pygments
-latest: 3.1
+latest: "3.2"
 
 foreman_version: 1.13
 


### PR DESCRIPTION
The latest version is 3.2, however the page currently displays a warning that 3.1 is the most recent stable (false).

You can see that on http://www.katello.org/docs/3.2/installation/index.html