### PR TITLE
Fixes #17517 - default to Puppet 4 on new Katello installs

### DIFF
--- a/_includes/repositories.html
+++ b/_includes/repositories.html
@@ -16,9 +16,10 @@ yum-config-manager --enable rhel-6-server-optional-rpms
 
 <div id="el6" markdown="1">
 ```bash
+yum -y update
 yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/katello/el6/x86_64/katello-repos-latest.rpm
 yum -y localinstall http://yum.theforeman.org/releases/{{ site.foreman_version }}/el6/x86_64/foreman-release.rpm
-yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm
+yum -y localinstall https://yum.puppetlabs.com/puppetlabs-release-pc1-el-6.noarch.rpm
 yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 yum -y install foreman-release-scl
 ```
@@ -38,7 +39,7 @@ yum-config-manager --enable rhel-7-server-extras-rpms
 ```bash
 yum -y localinstall http://fedorapeople.org/groups/katello/releases/yum/{{ site.version }}/katello/el7/x86_64/katello-repos-latest.rpm
 yum -y localinstall http://yum.theforeman.org/releases/{{ site.foreman_version  }}/el7/x86_64/foreman-release.rpm
-yum -y localinstall http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm
+yum -y localinstall https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm
 yum -y localinstall http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum -y install foreman-release-scl
 ```


### PR DESCRIPTION
The current documentation will install Puppet 3 if you copy/paste. This patch
alters the snippet to use Puppet 4 repos by default.